### PR TITLE
Fix typo

### DIFF
--- a/articles/storage/blobs/data-lake-storage-handle-data-using-databricks.md
+++ b/articles/storage/blobs/data-lake-storage-handle-data-using-databricks.md
@@ -93,7 +93,7 @@ V této části vytvoříte pomocí portálu Azure pracovní prostor služby Azu
 
     * Zadejte název clusteru.
     * Pro účely tohoto článku vytvořte cluster s modulem runtime verze **4.2**.
-    * Nezapomeňte zaškrtnout políčko **Terminate after \_\_ minutes of inactivity** (Ukončit po __ minutách neaktivity). Zadejte dobu (v minutách), po které se má ukončit činnost clusteru, pokud se cluster nepoužívá.
+    * Nezapomeňte zaškrtnout políčko **Terminate after \_\_ minutes of inactivity** (Ukončit po \_\_ minutách neaktivity). Zadejte dobu (v minutách), po které se má ukončit činnost clusteru, pokud se cluster nepoužívá.
 
     Vyberte **Vytvořit cluster**. Po spuštění clusteru můžete ke clusteru připojit poznámkové bloky a spouštět úlohy Spark.
 


### PR DESCRIPTION
Typo: `\_\_` -> `\_\_`
Označení pomocí `\_\_` zvýrazní. Chcete-li jednoduše zobrazit `\_\_`, musíte uniknout do `\_\_`.