### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-databricks/databricks-extract-load-sql-data-warehouse.md
+++ b/articles/azure-databricks/databricks-extract-load-sql-data-warehouse.md
@@ -96,7 +96,7 @@ V této části vytvoříte pomocí portálu Azure pracovní prostor služby Azu
 
     * Zadejte název clusteru.
     * Pro účely tohoto článku vytvořte cluster s modulem runtime verze **4.1 nebo vyšší**.
-    * Nezapomeňte zaškrtnout políčko **Terminate after \_\_ minutes of inactivity** (Ukončit po __ minutách neaktivity). Zadejte dobu (v minutách), po které se má ukončit činnost clusteru, pokud se cluster nepoužívá.
+    * Nezapomeňte zaškrtnout políčko **Terminate after \_\_ minutes of inactivity** (Ukončit po \_\_ minutách neaktivity). Zadejte dobu (v minutách), po které se má ukončit činnost clusteru, pokud se cluster nepoužívá.
     
     Vyberte **Vytvořit cluster**. Po spuštění clusteru můžete ke clusteru připojit poznámkové bloky a spouštět úlohy Spark.
 


### PR DESCRIPTION
Typo: __ -> `\_\_`.
In Markdown `__` is used to highlight. To simply show `__`, we must exit `\_\_`.