### PR TITLE
Fix `Angular` name being translated literally

### DIFF
--- a/articles/active-directory/develop/index.yml
+++ b/articles/active-directory/develop/index.yml
@@ -50,7 +50,7 @@ landingContent:
   linkLists:
   - linkListType: get-started
     links:
-    - text: Úhlová
+    - text: Angular
       url: quickstart-v2-angular.md
     - text: JavaScript – tok ověřovacího kódu
       url: quickstart-v2-javascript-auth-code.md


### PR DESCRIPTION
The name of `Angular` framework was translated literally to Czech language.